### PR TITLE
added checker script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-checker/old_value

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+checker/old_value

--- a/checker/run
+++ b/checker/run
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -ex
+
+cfg_dir=$(dirname "$0")
+
+. "$cfg_dir"/cfg.sh
+
+if [ -z "$url" ] | [ -z "$pattern" ] | [ -z "$branch" ] | [ -z "$message" ]; then
+    echo "Required fields url, pattern, branch and message not found in $cfg_dir/cfg.sh"
+    exit 1
+fi
+
+content=$(curl "$url")
+
+new_value=$(echo "$content" | grep -oP "$pattern" | head -1)
+
+if [ -z "$new_value" ]; then
+    echo "Expected pattern $pattern not found in $url"
+    exit 1
+fi
+
+trap 'echo $new_value | tee $cfg_dir/old_value' HUP INT TERM EXIT
+
+old_value=$(cat "$cfg_dir"/old_value || echo "")
+
+if [ "$new_value" != "$old_value" ]; then
+    (
+        tmp=$(mktemp -d)
+        trap "rm -rf $tmp" HUP INT TERM EXIT
+        cd "$tmp"
+        git clone https://github.com/snapcore/spread-launcher
+        cd spread-launcher
+        git fetch
+        git checkout "$branch"
+        git commit --allow-empty -m "$message"
+        git push
+    )
+fi

--- a/checker/run
+++ b/checker/run
@@ -2,12 +2,10 @@
 
 set -ex
 
-cfg_dir=$(dirname "$0")
+. $(dirname "$0")/../options
 
-. "$cfg_dir"/cfg.sh
-
-if [ -z "$url" ] | [ -z "$pattern" ] | [ -z "$branch" ] | [ -z "$message" ]; then
-    echo "Required fields url, pattern, branch and message not found in $cfg_dir/cfg.sh"
+if [ -z "$url" ] | [ -z "$pattern" ] | [ -z "$message" ]; then
+    echo "Required fields url, pattern and message not found in ../options"
     exit 1
 fi
 
@@ -25,15 +23,6 @@ trap 'echo $new_value | tee $cfg_dir/old_value' HUP INT TERM EXIT
 old_value=$(cat "$cfg_dir"/old_value || echo "")
 
 if [ "$new_value" != "$old_value" ]; then
-    (
-        tmp=$(mktemp -d)
-        trap "rm -rf $tmp" HUP INT TERM EXIT
-        cd "$tmp"
-        git clone https://github.com/snapcore/spread-launcher
-        cd spread-launcher
-        git fetch
-        git checkout "$branch"
-        git commit --allow-empty -m "$message"
-        git push
-    )
+    git commit --allow-empty -m "$message ($new_value)"
+    git push
 fi

--- a/checker/run
+++ b/checker/run
@@ -9,15 +9,13 @@ if [ -z "$pattern_extractor" ] | [ -z "$message" ]; then
     exit 1
 fi
 
-new_value=$(eval "$pattern_extractor")
+new_value=$(eval "$pattern_extractor" | tr -d '\r')
 if [ -z "$new_value" ]; then
     echo "$pattern_extractor didn't found anything"
     exit 1
 fi
 
-old_value_path=$(dirname "$0")/old_value
-trap 'echo $new_value | tee $old_value_path' HUP INT TERM EXIT
-old_value=$(cat "$old_value_path" || echo "")
+old_value=$(git log -1 --pretty=%B | head -1 | perl -pe "s|$message \((.*)\)|\1|")
 
 if [ "$new_value" != "$old_value" ]; then
     git commit --allow-empty -m "$message ($new_value)"

--- a/checker/run
+++ b/checker/run
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-set -ex
+set -uex
 
-. $(dirname "$0")/../options
+. "$(dirname "$0")"/../options
 
 if [ -z "$pattern_extractor" ] | [ -z "$message" ]; then
     echo "Required fields pattern_extractor and message not found in ../options"

--- a/checker/run
+++ b/checker/run
@@ -4,18 +4,18 @@ set -uex
 
 . "$(dirname "$0")"/../options
 
-if [ -z "$pattern_extractor" ] | [ -z "$message" ]; then
+if [ -z "$pattern_extractor" -o -z "$message" ]; then
     echo "Required fields pattern_extractor and message not found in ../options"
     exit 1
 fi
 
 new_value=$(eval "$pattern_extractor" | tr -d '\r')
 if [ -z "$new_value" ]; then
-    echo "$pattern_extractor didn't found anything"
+    echo "pattern extractor $pattern_extractor could not extract anything"
     exit 1
 fi
 
-old_value=$(git log -1 --pretty=%B | head -1 | perl -pe "s|$message \((.*)\)|\1|")
+old_value=$(git log -1 --pretty=%B | head -1 | sed -e "s|$message (\(.*\))|\1|")
 
 if [ "$new_value" != "$old_value" ]; then
     git commit --allow-empty -m "$message ($new_value)"

--- a/checker/run
+++ b/checker/run
@@ -4,23 +4,20 @@ set -ex
 
 . $(dirname "$0")/../options
 
-if [ -z "$url" ] | [ -z "$pattern" ] | [ -z "$message" ]; then
-    echo "Required fields url, pattern and message not found in ../options"
+if [ -z "$pattern_extractor" ] | [ -z "$message" ]; then
+    echo "Required fields pattern_extractor and message not found in ../options"
     exit 1
 fi
 
-content=$(curl "$url")
-
-new_value=$(echo "$content" | grep -oP "$pattern" | head -1)
-
+new_value=$(eval "$pattern_extractor")
 if [ -z "$new_value" ]; then
-    echo "Expected pattern $pattern not found in $url"
+    echo "$pattern_extractor didn't found anything"
     exit 1
 fi
 
-trap 'echo $new_value | tee $cfg_dir/old_value' HUP INT TERM EXIT
-
-old_value=$(cat "$cfg_dir"/old_value || echo "")
+old_value_path=$(dirname "$0")/old_value
+trap 'echo $new_value | tee $old_value_path' HUP INT TERM EXIT
+old_value=$(cat "$old_value_path" || echo "")
 
 if [ "$new_value" != "$old_value" ]; then
     git commit --allow-empty -m "$message ($new_value)"


### PR DESCRIPTION
This script pushes a new commit to a spread-launcher branch when changes are detected on a remote http resource in order to trigger a new build.

It expects to find a `options` file where the `pattern_extractor` and `message` are defined. `pattern_extractor` should be all the required code to fetch a new target value from a remote url. After eval'ing it the new value is compared with the previous one (extracted from the previous commit message, if any) and if they are different, it issues an empty commit to https://github.com/snapcore/spread-launcher on the current branch with `$message ($new_value)` as the commit message.

The user running the script must have git configured and be able to push to the snapcore/spread-launcher repo.