### PR TITLE
just send "Build now" when triggering the PPA build

### DIFF
--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -63,7 +63,7 @@ execute: |
             for suffix in "" "-zesty" "-artful" "-trusty"; do
                 curl -X POST -v -b /tmp/cookies.txt \
                      --referer https://code.launchpad.net/~snappy-dev/+recipe/snapd-vendor-daily${suffix}/ \
-                     -d 'field.archive=%7Esnappy-dev%2Fubuntu%2Fedge&field.distroseries=269&field.distroseries-empty-marker=1&field.archive-empty-marker=1&field.actions.request=Request+builds' \
+                     -d 'field.actions.build=Build%20now' \
                      https://code.launchpad.net/~snappy-dev/+recipe/snapd-vendor-daily${suffix}/+request-builds
             done
         fi


### PR DESCRIPTION
This is a bit of an experiment that we might need to revert. The issue right now is that the POST sends some very specific fields (like distroseries=269) that look like they are not needed and are in fact harmful when we want to build for e.g. artful (which is not distroseries=269). I inspected the headers and I think if we just send "Build%20now" the PPA will use the defaults which should be fine.

AFAICS there is no other way of trying this than merging and triggering a spread-cron run for snapd-vendor-sync. So I would like to try that and see if we get builds for xenial,zesty,artful and trusty this way.

