### PR TITLE
Skip manual branches

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -26,6 +26,11 @@ check(){
         exit 1
     fi
 
+    if [ "$manual" = "true" ]; then
+        echo "Manual branches are skipped"
+        return
+    fi
+
     total_commits=$(git rev-list --count HEAD)
     n=0
     while [ $n -lt $total_commits ]; do


### PR DESCRIPTION
The idea of this change is to be able to run tests on testflinger or any
other test runner by skipping branches that won't be triggered spread-
cron snap.