### PR TITLE
Add configure files as part of the sync

### DIFF
--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -17,7 +17,7 @@ prepare: |
 
 restore: |
     rm -f /tmp/id_rsa /tmp/cookies.txt
-    rm -rf origin $TARGET_DIR
+    rm -rf origin $TARGET_DIR /tmp/$TARGET_DIR
 
     apt remove -y git golang-1.6 openssh-client jq
 
@@ -41,7 +41,9 @@ execute: |
     eval `ssh-agent -s`
     mkdir -p ${HOME}/.ssh && ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
     ssh-agent $(ssh-add /tmp/id_rsa; git clone git+ssh://snappy-m-o@git.launchpad.net/snapd-vendor /tmp/$TARGET_DIR)
-    mkdir -p $TARGET_DIR && mv /tmp/$TARGET_DIR/.git $TARGET_DIR && rm -rf /tmp/$TARGET_DIR
+    mkdir -p $TARGET_DIR
+    mv /tmp/$TARGET_DIR/.git $TARGET_DIR
+    mv /tmp/$TARGET_DIR/commits $TARGET_DIR || true
     cp -ar origin/. $TARGET_DIR
 
     # configure git locally
@@ -53,6 +55,9 @@ execute: |
     govendor sync
 
     if [ $(git ls-files -dmo | wc -l) != "0" ]; then
+        # add the commit information
+        echo "master:$origin_commit" >> commits
+
         # if something was deleted, changed or added commit and push to the target repo
         git add .
         # guard against commited and later ignored files..


### PR DESCRIPTION
Currently the files named "configure" are not sent to the syc-vendor
repo because configure name is on the .ignore file and prevents that
those files are added as part of the commits.
There are several files which were not copied so far:

./tests/lib/snaps/config-versions-v2/meta/hooks/configure
./tests/lib/snaps/config-versions/meta/hooks/configure
./tests/lib/snaps/snapctl-hooks/meta/hooks/configure
./tests/lib/snaps/basic-hooks/meta/hooks/configure
./tests/lib/snaps/snapctl-hooks-v2/meta/hooks/configure
./tests/lib/snaps/failing-config-hooks/meta/hooks/configure
./tests/lib/snaps/test-snapd-with-configure/meta/hooks/configure
./tests/lib/snaps/snapctl-from-snap/meta/hooks/configure
./tests/lib/snaps/snap-hooks/meta/hooks/configure