### PR TITLE
Adding commits information to snapd-vendor launchpad repo

### DIFF
--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -17,7 +17,7 @@ prepare: |
 
 restore: |
     rm -f /tmp/id_rsa /tmp/cookies.txt
-    rm -rf origin $TARGET_DIR
+    rm -rf origin $TARGET_DIR /tmp/$TARGET_DIR
 
     apt remove -y git golang-1.6 openssh-client jq
 
@@ -41,7 +41,9 @@ execute: |
     eval `ssh-agent -s`
     mkdir -p ${HOME}/.ssh && ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
     ssh-agent $(ssh-add /tmp/id_rsa; git clone git+ssh://snappy-m-o@git.launchpad.net/snapd-vendor /tmp/$TARGET_DIR)
-    mkdir -p $TARGET_DIR && mv /tmp/$TARGET_DIR/.git $TARGET_DIR && rm -rf /tmp/$TARGET_DIR
+    mkdir -p $TARGET_DIR
+    mv /tmp/$TARGET_DIR/.git $TARGET_DIR
+    mv /tmp/$TARGET_DIR/commits $TARGET_DIR || true
     cp -ar origin/. $TARGET_DIR
 
     # configure git locally
@@ -53,6 +55,9 @@ execute: |
     govendor sync
 
     if [ $(git ls-files -dmo | wc -l) != "0" ]; then
+        # add the commit information
+        echo "master:$origin_commit" >> commits
+
         # if something was deleted, changed or added commit and push to the target repo
         git add .
         # guard against commited and later ignored files..


### PR DESCRIPTION
The idea is to add commits information on the launchpad repository,
which is gonna be used to keep tracking between the code on master and
the code used to build a core snap on edge channel.
This change will be used be another which is comming soon.