### PR TITLE
Adding commits information on snapd-vendor launchpad repo

### DIFF
--- a/options
+++ b/options
@@ -1,2 +1,2 @@
-pattern_extractor="curl -s https://api.travis-ci.org/repos/snapcore/snapd/builds?event_type=push | jq -j 'map(select(.result == 0) | select(.branch == \"master\")) | .[0].number'"
+pattern_extractor="if [ $(date +%H%M) \< "0030" ]; then echo ""; else date +%Y%m%d; fi"
 message="sync snapd-vendor with snapd after merge and green build"

--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -17,7 +17,7 @@ prepare: |
 
 restore: |
     rm -f /tmp/id_rsa /tmp/cookies.txt
-    rm -rf origin $TARGET_DIR /tmp/$TARGET_DIR
+    rm -rf origin $TARGET_DIR
 
     apt remove -y git golang-1.6 openssh-client jq
 
@@ -41,9 +41,7 @@ execute: |
     eval `ssh-agent -s`
     mkdir -p ${HOME}/.ssh && ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
     ssh-agent $(ssh-add /tmp/id_rsa; git clone git+ssh://snappy-m-o@git.launchpad.net/snapd-vendor /tmp/$TARGET_DIR)
-    mkdir -p $TARGET_DIR
-    mv /tmp/$TARGET_DIR/.git $TARGET_DIR
-    mv /tmp/$TARGET_DIR/commits $TARGET_DIR || true
+    mkdir -p $TARGET_DIR && mv /tmp/$TARGET_DIR/.git $TARGET_DIR && rm -rf /tmp/$TARGET_DIR
     cp -ar origin/. $TARGET_DIR
 
     # configure git locally
@@ -60,16 +58,8 @@ execute: |
 
         # if something was deleted, changed or added commit and push to the target repo
         git add .
-
         # guard against commited and later ignored files..
-        if git commit -am "Content updated ($origin_commit)"; then
-            # add the commits tracking information
-            target_commit=$(git rev-parse HEAD)
-            echo "master $origin_commit $target_commit" >> commits
-            git add commits
-            git commit -am "Commit information updated"
-
-            # push to target repository
+        if git commit -am"Content updated ($origin_commit)"; then
             ssh-agent $(ssh-add /tmp/id_rsa; git push)
 
             # trigger build

--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -24,7 +24,7 @@ restore: |
 execute: |
     # get origin merge commit
     . ./options
-    build_number=$(echo "$TRAVIS_COMMIT_MESSAGE" | sed -e "s/$message (\(.*\))/\1/")
+    build_number=$(curl -s https://api.travis-ci.org/repos/snapcore/snapd/builds?event_type=push | jq -j 'map(select(.result == 0) | select(.branch == "master")) | .[0].number')
     origin_commit=$(curl -s https://api.travis-ci.org/repos/snapcore/snapd/builds?number=$build_number | jq -j '.[0].commit')
 
     # clone origin repo and prepare for getting vendor dependencies

--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -55,13 +55,18 @@ execute: |
     govendor sync
 
     if [ $(git ls-files -dmo | wc -l) != "0" ]; then
-        # add the commit information
-        echo "master:$origin_commit" >> commits
-
         # if something was deleted, changed or added commit and push to the target repo
         git add .
+
         # guard against commited and later ignored files..
-        if git commit -am"Content updated ($origin_commit)"; then
+        if git commit -am "Content updated ($origin_commit)"; then
+            # add the commits tracking information
+            target_commit=$(git rev-parse HEAD)
+            echo "master $origin_commit $target_commit" >> commits
+            git add commits
+            git commit -am "Commit information updated"
+
+            # push to target repository
             ssh-agent $(ssh-add /tmp/id_rsa; git push)
 
             # trigger build

--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -17,7 +17,7 @@ prepare: |
 
 restore: |
     rm -f /tmp/id_rsa /tmp/cookies.txt
-    rm -rf origin $TARGET_DIR /tmp/$TARGET_DIR
+    rm -rf origin $TARGET_DIR
 
     apt remove -y git golang-1.6 openssh-client jq
 
@@ -41,9 +41,7 @@ execute: |
     eval `ssh-agent -s`
     mkdir -p ${HOME}/.ssh && ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
     ssh-agent $(ssh-add /tmp/id_rsa; git clone git+ssh://snappy-m-o@git.launchpad.net/snapd-vendor /tmp/$TARGET_DIR)
-    mkdir -p $TARGET_DIR
-    mv /tmp/$TARGET_DIR/.git $TARGET_DIR
-    mv /tmp/$TARGET_DIR/commits $TARGET_DIR || true
+    mkdir -p $TARGET_DIR && mv /tmp/$TARGET_DIR/.git $TARGET_DIR && rm -rf /tmp/$TARGET_DIR
     cp -ar origin/. $TARGET_DIR
 
     # configure git locally
@@ -55,9 +53,6 @@ execute: |
     govendor sync
 
     if [ $(git ls-files -dmo | wc -l) != "0" ]; then
-        # add the commit information
-        echo "master:$origin_commit" >> commits
-
         # if something was deleted, changed or added commit and push to the target repo
         git add .
         # guard against commited and later ignored files..

--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -55,18 +55,13 @@ execute: |
     govendor sync
 
     if [ $(git ls-files -dmo | wc -l) != "0" ]; then
+        # add the commit information
+        echo "master:$origin_commit" >> commits
+
         # if something was deleted, changed or added commit and push to the target repo
         git add .
-
         # guard against commited and later ignored files..
-        if git commit -am "Content updated ($origin_commit)"; then
-            # add the commits tracking information
-            target_commit=$(git rev-parse HEAD)
-            echo "master $origin_commit $target_commit" >> commits
-            git add commits
-            git commit -am "Commit information updated"
-
-            # push to target repository
+        if git commit -am"Content updated ($origin_commit)"; then
             ssh-agent $(ssh-add /tmp/id_rsa; git push)
 
             # trigger build

--- a/target/tasks/snapd-vendor-sync/task.yaml
+++ b/target/tasks/snapd-vendor-sync/task.yaml
@@ -17,7 +17,7 @@ prepare: |
 
 restore: |
     rm -f /tmp/id_rsa /tmp/cookies.txt
-    rm -rf origin $TARGET_DIR
+    rm -rf origin $TARGET_DIR /tmp/$TARGET_DIR
 
     apt remove -y git golang-1.6 openssh-client jq
 
@@ -41,7 +41,9 @@ execute: |
     eval `ssh-agent -s`
     mkdir -p ${HOME}/.ssh && ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
     ssh-agent $(ssh-add /tmp/id_rsa; git clone git+ssh://snappy-m-o@git.launchpad.net/snapd-vendor /tmp/$TARGET_DIR)
-    mkdir -p $TARGET_DIR && mv /tmp/$TARGET_DIR/.git $TARGET_DIR && rm -rf /tmp/$TARGET_DIR
+    mkdir -p $TARGET_DIR
+    mv /tmp/$TARGET_DIR/.git $TARGET_DIR
+    mv /tmp/$TARGET_DIR/commits $TARGET_DIR || true
     cp -ar origin/. $TARGET_DIR
 
     # configure git locally
@@ -53,6 +55,9 @@ execute: |
     govendor sync
 
     if [ $(git ls-files -dmo | wc -l) != "0" ]; then
+        # add the commit information
+        echo "master:$origin_commit" >> commits
+
         # if something was deleted, changed or added commit and push to the target repo
         git add .
         # guard against commited and later ignored files..


### PR DESCRIPTION
The idea is to add commits information on the launchpad repository,
which is gonna be used to keep tracking between the code on master and
the code used to build a core snap on edge channel.

This change will be used be another which is comming soon.