### PR TITLE
Adding dependencies to build core snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -54,3 +54,8 @@ parts:
             - bin/
             - meta/hooks
             - usr/
+    py:
+        plugin: python2
+        python-packages:
+            - urlparse2
+            - launchpadlib


### PR DESCRIPTION
We need that to build the core snap as part of the spread-cron execution