### PR TITLE
Snapd vendor sync - nightly execution

### DIFF
--- a/target/spread.yaml
+++ b/target/spread.yaml
@@ -4,7 +4,8 @@ path: /sync
 
 backends:
     linode:
-        type:
+        plan: 2GB
+        location: Fremont
         key: "$(HOST: echo $SPREAD_LINODE_KEY)"
         environment:
             GOPATH: /home/gopath


### PR DESCRIPTION
The idea is to sync once a day and make it before the core snap is built. By doing that we will be able to make daily executions using the core snap on edge chanel.