### PR TITLE
Fix pull with conflicts

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -65,7 +65,10 @@ while true; do
                 branch="${remote#origin/}"
                 git branch --track "$branch" "$remote";
                 git checkout "$branch"
-                git pull
+                if ! git pull; then
+                    git branch -D "$branch"
+                    git pull "$branch"
+                fi
                 ( check )
             fi
         done

--- a/cron.sh
+++ b/cron.sh
@@ -65,9 +65,11 @@ while true; do
                 branch="${remote#origin/}"
                 git branch --track "$branch" "$remote";
                 git checkout "$branch"
+                # When the branch cannot be pulled because of any conflict, the remote branch is checkedout
                 if ! git pull; then
+                    git checkout master
                     git branch -D "$branch"
-                    git pull "$branch"
+                    git checkout "$branch"
                 fi
                 ( check )
             fi

--- a/cron.sh
+++ b/cron.sh
@@ -65,12 +65,7 @@ while true; do
                 branch="${remote#origin/}"
                 git branch --track "$branch" "$remote";
                 git checkout "$branch"
-                # When the branch cannot be pulled because of any conflict, the remote branch is checkedout
-                if ! git pull; then
-                    git checkout master
-                    git branch -D "$branch"
-                    git checkout "$branch"
-                fi
+                git reset --hard "$remote"
                 ( check )
             fi
         done


### PR DESCRIPTION
Sometimes when there are conflicts to make a git pull, then it is required to delete the local branch and use the remote one. 