### PR TITLE
snapd-vendor-sync: fix for new c-vendor dir

### DIFF
--- a/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
+++ b/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
@@ -45,6 +45,7 @@ execute: |
     fi
     rm -rf .git
     sed -i 's|^vendor/\*/$||' .gitignore
+    sed -i 's|^c-vendor/\*/$||' .gitignore
     cd ..
 
     # clone target repo and copy origin over target
@@ -61,7 +62,6 @@ execute: |
 
     # get vendor dependencies on target repo
     ./get-deps.sh
-    govendor sync
 
     if [ $(git ls-files -dmo | wc -l) != "0" ]; then
         # add the commit information


### PR DESCRIPTION
The new `c-vendor` dir needs to be excluded from the `.gitignore`
so that it can be imported. This is done in this commit. It also
removes the now redundant `govendor sync`. Which will also be
useful once we removed govendor entirely and moved to `go.mod`.