### PR TITLE
snapd-vendor-sync: include "vendor/modules.txt" in generated source

### DIFF
--- a/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
+++ b/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
@@ -44,7 +44,7 @@ execute: |
         git reset --hard $origin_commit
     fi
     rm -rf .git
-    sed -i 's|^vendor/\*/$||' .gitignore
+    sed -i '/^vendor/d' .gitignore
     cd ..
 
     # clone target repo and copy origin over target


### PR DESCRIPTION
The vendor/modules.txt is vital for go.mod 1.18 to build the package and the existing code left it in `.gitignore` which means it is not part of the generated tar archive that is used to build the debian package. 

This commit fixes this and removed anything `vendor/` from the `.gitignore` which means that both the vendored source code and `vendor/modules.txt` are part of the (auto)generated tar file. This will fix the edge build failures.