### PR TITLE
snapd-vendor-sync: include "vendor/modules.txt" in generated source

### DIFF
--- a/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
+++ b/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
@@ -44,7 +44,7 @@ execute: |
         git reset --hard $origin_commit
     fi
     rm -rf .git
-    sed -i 's|^vendor/\*/$||' .gitignore
+    sed -i '/^vendor/d' .gitignore
     sed -i 's|^c-vendor/\*/$||' .gitignore
     cd ..
 


### PR DESCRIPTION
This is PR https://github.com/snapcore/spread-cron/pull/56 against master - it looks like I misunderstood how this works and the PR needs to go to master (just like https://github.com/snapcore/spread-cron/pull/55 went to master)

The vendor/modules.txt is vital for go.mod 1.18 to build the package and the existing code removed the "vendor/*" dir from `.gitignore` but did leave the  `vendor/modules.txt`.

This commit fixes this and removed anything `vendor/` from the `.gitignore`. This will fix the edge build failures.

