### PR TITLE
spread-vendor-sync: remove no longer used github.com/kardianos/govendor

### DIFF
--- a/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
+++ b/branches/snapd-vendor-sync/target/tasks/snapd-vendor-sync/task.yaml
@@ -21,8 +21,6 @@ prepare: |
     apt remove --purge -y golang golang-go
     dpkg -i go_$GOVERSION-*.deb
 
-    go get -u github.com/kardianos/govendor
-
     chmod 0600 /tmp/id_rsa
 
 restore: |


### PR DESCRIPTION
    git push --set-upstream origin fix-vendor-sync-more-2
